### PR TITLE
Fix calculation of closest entity

### DIFF
--- a/simulators/zombie-survival/Position.ts
+++ b/simulators/zombie-survival/Position.ts
@@ -2,7 +2,3 @@ export interface Position {
   x: number;
   y: number;
 }
-
-export function positionAsNumber(position: Position): number {
-  return position.x + position.y;
-}

--- a/simulators/zombie-survival/ZombieSurvival.spec.ts
+++ b/simulators/zombie-survival/ZombieSurvival.spec.ts
@@ -361,7 +361,7 @@ test("player gets killed behind walls", () => {
   expect(game.finished()).toBeTruthy();
 });
 
-test("zombie dies after player killing it", () => {
+test("player kills zombie and it doesn't hit afterwards", () => {
   const game = new ZombieSurvival([
     ["P", " "],
     [" ", "Z"],
@@ -373,6 +373,58 @@ test("zombie dies after player killing it", () => {
   expect(game.getState()).toStrictEqual([
     ["P", " "],
     [" ", " "],
+  ]);
+
+  expect(game.finished()).toBeTruthy();
+});
+
+test.only("player kills closest zombie", () => {
+  const game = new ZombieSurvival([
+    [" ", " ", "R", " ", "Z"],
+    [" ", " ", " ", " ", "B"],
+    [" ", "P", " ", "R", " "],
+    ["Z", " ", " ", " ", " "],
+    [" ", " ", "B", " ", " "],
+  ]);
+
+  game.step();
+
+  expect(game.getState()).toStrictEqual([
+    [" ", " ", "R", "Z", " "],
+    [" ", " ", " ", " ", "B"],
+    [" ", "P", " ", "R", " "],
+    [" ", "Z", " ", " ", " "],
+    [" ", " ", "B", " ", " "],
+  ]);
+
+  game.step();
+
+  expect(game.getState()).toStrictEqual([
+    [" ", " ", "R", " ", " "],
+    [" ", " ", " ", "Z", "B"],
+    [" ", "P", " ", "R", " "],
+    [" ", " ", " ", " ", " "],
+    [" ", " ", "B", " ", " "],
+  ]);
+
+  game.step();
+
+  expect(game.getState()).toStrictEqual([
+    [" ", " ", "R", " ", " "],
+    [" ", " ", "Z", " ", "B"],
+    [" ", "P", " ", "R", " "],
+    [" ", " ", " ", " ", " "],
+    [" ", " ", "B", " ", " "],
+  ]);
+
+  game.step();
+
+  expect(game.getState()).toStrictEqual([
+    [" ", " ", "R", " ", " "],
+    [" ", " ", " ", " ", "B"],
+    [" ", "P", " ", "R", " "],
+    [" ", " ", " ", " ", " "],
+    [" ", " ", "B", " ", " "],
   ]);
 
   expect(game.finished()).toBeTruthy();

--- a/simulators/zombie-survival/ZombieSurvival.spec.ts
+++ b/simulators/zombie-survival/ZombieSurvival.spec.ts
@@ -360,3 +360,20 @@ test("player gets killed behind walls", () => {
 
   expect(game.finished()).toBeTruthy();
 });
+
+test("zombie dies after player killing it", () => {
+  const game = new ZombieSurvival([
+    ["P", " "],
+    [" ", "Z"],
+  ]);
+
+  game.step();
+  game.step();
+
+  expect(game.getState()).toStrictEqual([
+    ["P", " "],
+    [" ", " "],
+  ]);
+
+  expect(game.finished()).toBeTruthy();
+});

--- a/simulators/zombie-survival/ZombieSurvival.ts
+++ b/simulators/zombie-survival/ZombieSurvival.ts
@@ -134,10 +134,6 @@ export class ZombieSurvival {
         break;
       }
 
-      if (zombie.dead()) {
-        continue;
-      }
-
       zombie.walk();
     }
   }

--- a/simulators/zombie-survival/ZombieSurvival.ts
+++ b/simulators/zombie-survival/ZombieSurvival.ts
@@ -134,6 +134,10 @@ export class ZombieSurvival {
         break;
       }
 
+      if (zombie.dead()) {
+        continue;
+      }
+
       zombie.walk();
     }
   }

--- a/simulators/zombie-survival/lib/closestEntity.ts
+++ b/simulators/zombie-survival/lib/closestEntity.ts
@@ -1,13 +1,14 @@
 import { Entity } from "../entities/Entity";
-import { positionAsNumber } from "../Position";
 
 export interface ClosestEntityScore {
-  score: number;
+  distance: number;
   target: Entity;
 }
 
 export function closestEntity(entity: Entity, targets: Entity[]): Entity {
-  const entityPosition = positionAsNumber(entity.getPosition());
+  const entityPosition = entity.getPosition();
+  const x1 = entityPosition.x;
+  const y1 = entityPosition.y;
   const scores: ClosestEntityScore[] = [];
 
   for (const target of targets) {
@@ -15,16 +16,18 @@ export function closestEntity(entity: Entity, targets: Entity[]): Entity {
       continue;
     }
 
-    const targetPosition = positionAsNumber(target.getPosition());
-    const score = Math.abs(entityPosition - targetPosition);
+    const targetPosition = target.getPosition();
+    const x2 = targetPosition.x;
+    const y2 = targetPosition.y;
+    const distance = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
 
-    scores.push({ target, score });
+    scores.push({ distance, target });
   }
 
   if (scores.length === 0) {
     throw new Error("No alive targets found");
   }
 
-  scores.sort((a, b) => a.score - b.score);
+  scores.sort((a, b) => a.distance - b.distance);
   return scores[0].target;
 }


### PR DESCRIPTION
You see, in this case:
![dd (1)](https://github.com/user-attachments/assets/c945aaef-bb62-4e93-8c84-6c37c9e5398b)
First zombie kills player even though it's theoretically should be dead after player's second shot. Instead, player starts shooting another zombie and gets killed by the closest one. The problem here is the algorithm I used for determining closest entity.

I changed and now it uses Pythagorean theorem to find the distance between two points and use it in scoring.