### PR TITLE
Watch page

### DIFF
--- a/app/games/[gameId]/page.tsx
+++ b/app/games/[gameId]/page.tsx
@@ -25,9 +25,7 @@ export default function GamePage({ params }: { params: { gameId: string } }) {
             <p className="ml-4">Game starting...</p>
           </div>
         ) : (
-          results.map((result) => (
-            <Result autoPlay={true} result={result} key={result._id} />
-          ))
+          results.map((result) => <Result result={result} key={result._id} />)
         )}
       </div>
     </div>

--- a/app/games/[gameId]/result.tsx
+++ b/app/games/[gameId]/result.tsx
@@ -3,7 +3,8 @@
 import { Doc } from "@/convex/_generated/dataModel";
 import { api } from "@/convex/_generated/api";
 import { useQuery } from "convex/react";
-import { Visualizer } from "./visualizer";
+import { ResultStatus } from "@/app/result-status";
+import { Visualizer } from "../../visualizer";
 import Link from "next/link";
 
 export const Result = ({ result }: { result: Doc<"results"> }) => {
@@ -33,11 +34,7 @@ export const Result = ({ result }: { result: Doc<"results"> }) => {
       </Link>
       <Visualizer map={result.map} autoStart={true} />
       <div className="flex flex-col">
-        <div
-          className={`font-bold ${result.isWin ? "text-green-500" : "text-red-500"}`}
-        >
-          {result.isWin ? "Won" : "Lost"}
-        </div>
+        <ResultStatus result={result} />
         {result.reasoning !== "" && <p>{result.reasoning}</p>}
       </div>
     </div>

--- a/app/header.tsx
+++ b/app/header.tsx
@@ -33,7 +33,7 @@ export default function Header() {
       </Link>
 
       <nav className="flex items-center space-x-4">
-        <Link href="/">
+        <Link href="/watch">
           <Button variant="ghost">Watch</Button>
         </Link>
         <Link href="/play">

--- a/app/play/[level]/page.tsx
+++ b/app/play/[level]/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Button } from "@/components/ui/button";
-import { Visualizer } from "@/app/games/[gameId]/visualizer";
+import { Visualizer } from "../../visualizer";
 import { Map } from "@/app/map";
 import Link from "next/link";
 import { ChevronLeftIcon } from "@radix-ui/react-icons";

--- a/app/result-status.tsx
+++ b/app/result-status.tsx
@@ -1,0 +1,11 @@
+import { Doc } from "@/convex/_generated/dataModel";
+
+export function ResultStatus({ result }: { result: Doc<"results"> }) {
+  return (
+    <div
+      className={`font-bold ${result.isWin ? "text-green-500" : "text-red-500"}`}
+    >
+      {result.isWin ? "Won" : "Lost"}
+    </div>
+  );
+}

--- a/app/watch/page.tsx
+++ b/app/watch/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import Result from "./result";
+import { api } from "@/convex/_generated/api";
+
+export default function GamePage() {
+  const results = useQuery(api.results.getLastCompletedResults);
+
+  if (results === undefined) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <div className="container mx-auto min-h-screen flex flex-wrap justify-between pt-12 pb-24 gap-x-2 gap-y-8">
+      {results.map((result) => (
+        <Result key={result._id} result={result} />
+      ))}
+    </div>
+  );
+}

--- a/app/watch/result.tsx
+++ b/app/watch/result.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ResultStatus } from "../result-status";
+import { type ResultWithGame } from "@/convex/results";
+import { Visualizer } from "../visualizer";
+
+export default function Result({ result }: { result: ResultWithGame }) {
+  return (
+    <div className="flex flex-col gap-2 items-center">
+      {result.game !== null && (
+        <div className="flex gap-2">
+          <ResultStatus result={result} />
+          <p>{result.game.modelId}</p>
+        </div>
+      )}
+      <Visualizer autoReplay autoStart controls={false} map={result.map} />
+    </div>
+  );
+}


### PR DESCRIPTION
This is how it looks:

<img width="1439" alt="Screenshot 2024-10-16 at 8 33 04 PM" src="https://github.com/user-attachments/assets/3b774f1e-77eb-430c-8225-5537095127a7">


This is how it works:
It gets last 20 completed results and shows them on the page.

What can be improved:
I don't like the way results are displayed with simple flexbox, later we might want to hook up some library to have it displayed more nicely.

As part of this PR:
- moved Visualizer to /app because re-used on multiple pages
- moved ResultStatus to separate component in /app
- added ability to have infinite replay with `autoReplay` option on Visualizer
- added option `controls` to hide controls on Visualizer

Closes #38 