### PR TITLE
Fix maps TS iterator build error

### DIFF
--- a/convex/maps.ts
+++ b/convex/maps.ts
@@ -98,12 +98,12 @@ export const seedMaps = internalMutation({
       await ctx.db.delete(map._id);
     }
 
-    for (const [idx, map] of LEVELS.entries()) {
+    LEVELS.forEach((map, idx) => {
       ctx.db.insert("maps", {
         level: idx + 1,
         grid: map.grid,
       });
-    }
+    });
   },
 });
 


### PR DESCRIPTION
Right now deployment fails because it's trying to loop over `.entries()` of array, without valid TS option it throws build error. Instead I replaced it with `.forEach`.