### PR TITLE
Level Rankings on play page

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -34,7 +34,7 @@ const LeaderBoard = () => {
   const globalRanking = useQuery(api.leaderboard.getGlobalRankings) as
     | Ranking[]
     | undefined;
-  const levelRanking = useQuery(api.leaderboard.getAllLevelRankings) as
+  const levelRanking = useQuery(api.leaderboard.getLevelRankings, {}) as
     | Ranking[]
     | undefined;
 

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -34,7 +34,7 @@ const LeaderBoard = () => {
   const globalRanking = useQuery(api.leaderboard.getGlobalRankings) as
     | Ranking[]
     | undefined;
-  const levelRanking = useQuery(api.leaderboard.getLevelRankings) as
+  const levelRanking = useQuery(api.leaderboard.getAllLevelRankings) as
     | Ranking[]
     | undefined;
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,6 +50,9 @@ export default function GamePage() {
       <div className="space-y-8">
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold">AI Leaderboard</h2>
+          <Link href="/leaderboard" passHref>
+            <Button variant="link">Leaderboard Page</Button>
+          </Link>
         </div>
         <div className="overflow-x-auto">
           <Table>

--- a/app/play/[level]/page.tsx
+++ b/app/play/[level]/page.tsx
@@ -350,6 +350,9 @@ export default function PlayLevelPage({
         <div className="space-y-8">
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-bold">AI Leaderboard</h2>
+            <Link href="/leaderboard" passHref>
+              <Button variant="link">Leaderboard Page</Button>
+            </Link>
           </div>
           <div className="overflow-x-auto">
             <Table>

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -21,33 +21,21 @@ export const getGlobalRankings = query({
   },
 });
 
-export const getAllLevelRankings = query({
-  handler: async ({ db }) => {
-    const res = await db.query("levelRankings").collect();
-
-    const sortedResults = res.sort((a, b) => {
-      if (a.level < b.level) {
-        return -1;
-      }
-      if (a.level > b.level) {
-        return 1;
-      }
-      return 0;
-    });
-
-    return sortedResults;
-  },
-});
-
 export const getLevelRankings = query({
   args: {
-    level: v.number(),
+    level: v.optional(v.number()),
   },
-  handler: async ({ db }, { level }) => {
-    const res = await db
-      .query("levelRankings")
-      .filter((q) => q.eq(q.field("level"), level))
-      .collect();
+  handler: async ({ db }, args) => {
+    let res;
+
+    if (args.level) {
+      res = await db
+        .query("levelRankings")
+        .filter((q) => q.eq(q.field("level"), args.level))
+        .collect();
+    } else {
+      res = await db.query("levelRankings").collect();
+    }
 
     const sortedResults = res.sort((a, b) => {
       if (a.level < b.level) {

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -21,9 +21,33 @@ export const getGlobalRankings = query({
   },
 });
 
-export const getLevelRankings = query({
+export const getAllLevelRankings = query({
   handler: async ({ db }) => {
     const res = await db.query("levelRankings").collect();
+
+    const sortedResults = res.sort((a, b) => {
+      if (a.level < b.level) {
+        return -1;
+      }
+      if (a.level > b.level) {
+        return 1;
+      }
+      return 0;
+    });
+
+    return sortedResults;
+  },
+});
+
+export const getLevelRankings = query({
+  args: {
+    level: v.number(),
+  },
+  handler: async ({ db }, { level }) => {
+    const res = await db
+      .query("levelRankings")
+      .filter((q) => q.eq(q.field("level"), level))
+      .collect();
 
     const sortedResults = res.sort((a, b) => {
       if (a.level < b.level) {

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -27,11 +27,11 @@ export const getLevelRankings = query({
   },
   handler: async ({ db }, args) => {
     let res;
-
-    if (args.level) {
+    const level = args.level;
+    if (level) {
       res = await db
         .query("levelRankings")
-        .filter((q) => q.eq(q.field("level"), args.level))
+        .withIndex("by_level", (q) => q.eq("level", level))
         .collect();
     } else {
       res = await db.query("levelRankings").collect();

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -56,7 +56,9 @@ export default defineSchema({
     wins: v.number(),
     promptId: v.optional(v.id("prompts")),
     losses: v.number(),
-  }).index("by_modelId_level_promptId", ["modelId", "level", "promptId"]),
+  })
+    .index("by_modelId_level_promptId", ["modelId", "level", "promptId"])
+    .index("by_level", ["level"]),
   attempts: defineTable({
     grid: v.array(v.array(v.string())),
     didWin: v.boolean(),


### PR DESCRIPTION
This is a pr for #124, it includes:

- Renaming a leaderboard query
- Creating a new leaderboard query for getting rankings per level
- Displaying the leaderboard data for each level on the play page

This has now been edited to combine the two leaderboard queries and have an optional level that can be passed in.